### PR TITLE
Upgrade 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "nacos-sdk-rust-binding-node"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["CheirshCai <785427346@qq.com>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -18,8 +18,7 @@ crate-type = ["cdylib"]
 napi = { version = "2", default-features = false, features = ["napi4", "async"] }
 napi-derive = "2"
 
-# version = ^0.2
-nacos-sdk = { git = "https://github.com/nacos-group/nacos-sdk-rust.git", features = ["async"] }
+nacos-sdk = { version = "0.2.3", features = ["async"] }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 lazy_static = "1.4.0"

--- a/npm/android-arm-eabi/package.json
+++ b/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-android-arm-eabi",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "android"
   ],

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-android-arm64",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "android"
   ],

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-darwin-arm64",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-universal/package.json
+++ b/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-darwin-universal",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-darwin-x64",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "darwin"
   ],

--- a/npm/freebsd-x64/package.json
+++ b/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-freebsd-x64",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "freebsd"
   ],

--- a/npm/linux-arm-gnueabihf/package.json
+++ b/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-linux-arm-gnueabihf",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-linux-arm64-gnu",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-linux-arm64-musl",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-linux-x64-gnu",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-linux-x64-musl",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-win32-arm64-msvc",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "win32"
   ],

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-win32-ia32-msvc",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nacos-sdk-rust-binding-node-win32-x64-msvc",
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "binding",
     "ffi"
   ],
-  "version": "0.0.2-BETA",
+  "version": "0.0.2",
   "bugs": "https://github.com/opc-source/nacos-sdk-rust-binding-node/issues",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- bump: nacos-sdk = 0.2.3
- feat: use nacos-sdk-rust async api.