### PR TITLE
index.d.ts  error TS2371

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,17 +141,17 @@ export class NacosNamingClient {
    * Get all instances by service and group. default cluster=[], subscribe=true.
    * If it fails, pay attention to err
    */
-  getAllInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean = true): Promise<Array<NacosServiceInstance>>
+  getAllInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null): Promise<Array<NacosServiceInstance>>
   /**
    * Select instances whether healthy or not. default cluster=[], subscribe=true, healthy=true.
    * If it fails, pay attention to err
    */
-  selectInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean = true, healthy?: boolean = true): Promise<Array<NacosServiceInstance>>
+  selectInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null, healthy?: boolean | undefined | null): Promise<Array<NacosServiceInstance>>
   /**
    * Select one healthy instance. default cluster=[], subscribe=true.
    * If it fails, pay attention to err
    */
-  selectOneHealthyInstance(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean = true): Promise<NacosServiceInstance>
+  selectOneHealthyInstance(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null): Promise<NacosServiceInstance>
   /**
    * Add NacosNamingEventListener callback func, which listen the instance change.
    * If it fails, pay attention to err

--- a/index.d.ts
+++ b/index.d.ts
@@ -141,17 +141,17 @@ export class NacosNamingClient {
    * Get all instances by service and group. default cluster=[], subscribe=true.
    * If it fails, pay attention to err
    */
-  getAllInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null): Promise<Array<NacosServiceInstance>>
+  getAllInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | true): Promise<Array<NacosServiceInstance>>
   /**
    * Select instances whether healthy or not. default cluster=[], subscribe=true, healthy=true.
    * If it fails, pay attention to err
    */
-  selectInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null, healthy?: boolean | undefined | null): Promise<Array<NacosServiceInstance>>
+  selectInstances(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | true, healthy?: boolean | true): Promise<Array<NacosServiceInstance>>
   /**
    * Select one healthy instance. default cluster=[], subscribe=true.
    * If it fails, pay attention to err
    */
-  selectOneHealthyInstance(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | undefined | null): Promise<NacosServiceInstance>
+  selectOneHealthyInstance(serviceName: string, group: string, clusters?: Array<string> | undefined | null, subscribe?: boolean | true): Promise<NacosServiceInstance>
   /**
    * Add NacosNamingEventListener callback func, which listen the instance change.
    * If it fails, pay attention to err

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -123,7 +123,7 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    #[napi(ts_arg_type = "boolean = true")] subscribe: Option<bool>,
+    subscribe: Option<bool>,
   ) -> Result<Vec<NacosServiceInstance>> {
     let rust_instances = self
       .inner
@@ -152,8 +152,8 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    #[napi(ts_arg_type = "boolean = true")] subscribe: Option<bool>,
-    #[napi(ts_arg_type = "boolean = true")] healthy: Option<bool>,
+    subscribe: Option<bool>,
+    healthy: Option<bool>,
   ) -> Result<Vec<NacosServiceInstance>> {
     let rust_instances = self
       .inner
@@ -183,7 +183,7 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    #[napi(ts_arg_type = "boolean = true")] subscribe: Option<bool>,
+    subscribe: Option<bool>,
   ) -> Result<NacosServiceInstance> {
     let rust_instance = self
       .inner

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -123,7 +123,7 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    subscribe: Option<bool>,
+    #[napi(ts_arg_type = "boolean | true")] subscribe: Option<bool>,
   ) -> Result<Vec<NacosServiceInstance>> {
     let rust_instances = self
       .inner
@@ -152,8 +152,8 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    subscribe: Option<bool>,
-    healthy: Option<bool>,
+    #[napi(ts_arg_type = "boolean | true")] subscribe: Option<bool>,
+    #[napi(ts_arg_type = "boolean | true")] healthy: Option<bool>,
   ) -> Result<Vec<NacosServiceInstance>> {
     let rust_instances = self
       .inner
@@ -183,7 +183,7 @@ impl NacosNamingClient {
     service_name: String,
     group: String,
     clusters: Option<Vec<String>>,
-    subscribe: Option<bool>,
+    #[napi(ts_arg_type = "boolean | true")] subscribe: Option<bool>,
   ) -> Result<NacosServiceInstance> {
     let rust_instance = self
       .inner


### PR DESCRIPTION
当 `tsconfig.json` 参数  `skipLibCheck` 配置为false 时，检查 `index.d.ts`  语法错误
![pr](https://github.com/opc-source/nacos-sdk-rust-binding-node/assets/17487028/83342b50-8251-4e5e-8496-ed70d496fa87)


去掉参数默认值后tsc编译成功